### PR TITLE
Show full path in template doc

### DIFF
--- a/lib/rspec/api_doc/section.rb
+++ b/lib/rspec/api_doc/section.rb
@@ -43,7 +43,7 @@ module RSpec
       end
 
       def request_path
-        @_group.request.path_info unless @_group.request.nil?
+        @_group.request.fullpath unless @_group.request.nil?
       end
 
       def recorded_request?


### PR DESCRIPTION
First of all, thank you for this gem! It is much easier to use than the other gems I looked at for generating documentation. Exactly what I wanted.

I noticed when trying to document the use of query strings, the query parameters were not being appended to the http request generated for the documentation. If this is a bug, I believe this pr would fix it. If I'm simply using the gem wrong, please let me know, and feel free to close this. 

Issue description: Previously the generated documentation was leaving out query strings from the request (`get /path/to/resources instead of the intended `get path/to/resources?query=string`). 