### PR TITLE
Fix use_host scheme

### DIFF
--- a/lib/rspec/api_doc/dsl.rb
+++ b/lib/rspec/api_doc/dsl.rb
@@ -30,15 +30,25 @@ module RSpec
       endpoint_macro :collection_endpoint
 
       def use_host(host)
+        uri = URI.parse(host)
+        host = uri.host
+        protocol = uri.scheme || "https"
         around do |ex|
           org_host = default_url_options[:host]
+          org_protocol = default_url_options[:protocol]
           default_url_options[:host] = host
+          default_url_options[:protocol] = protocol
           ex.run
           # Rails dislikes an explicit `nil` as the host, so check first
           if org_host
             default_url_options[:host] = org_host
           else
             default_url_options.delete(:host)
+          end
+          if org_protocol
+            default_url_options[:protocol] = org_protocol
+          else
+            default_url_options.delete(:protocol)
           end
         end
       end

--- a/rspec-api_doc.gemspec
+++ b/rspec-api_doc.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.9"
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "radius-spec"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.2"
 end


### PR DESCRIPTION
Previously when we used `use_host`, it would default back to `http` even if you specified `https` as part of the `host` string. This parses it as a URI and sets the protocol as well as the hostname.