### PR TITLE
Don't include blank JSON bodies

### DIFF
--- a/lib/rspec/api_doc/section.rb
+++ b/lib/rspec/api_doc/section.rb
@@ -43,7 +43,7 @@ module RSpec
       end
 
       def request_path
-        @_group.request.path_info unless @_group.request.nil?
+        @_group.request.fullpath unless @_group.request.nil?
       end
 
       def recorded_request?

--- a/lib/rspec/api_doc/templates/api_doc_json_template.md.erb
+++ b/lib/rspec/api_doc/templates/api_doc_json_template.md.erb
@@ -41,7 +41,7 @@ All <%= resource %> **must** be sent in an array nested under a top level
 | `<%= parameter.name %>` | `<%= parameter.type %>` | <%= '**Required.** ' if parameter.required? %><%= parameter.description %> |
 <% end %>
 
-<% if section.recorded_request? %>
+<% if section.recorded_request? && section.request_json.present? %>
 ### <span id="<%= section.header_ref %>-example">Example</span>
 
 <% if section.example_explanation.present? %>


### PR DESCRIPTION
GET requests typically don't include a JSON body, so we should skip including the request body in those cases.