### PR TITLE
Remove span tags from template

### DIFF
--- a/lib/rspec/api_doc/templates/api_doc_json_template.md.erb
+++ b/lib/rspec/api_doc/templates/api_doc_json_template.md.erb
@@ -10,7 +10,7 @@
 <% end %>
 <% sections.each do |section| %>
 
-## <span id="<%= section.header_ref %>"><%= section.header %></span>
+## <%= section.header %>
 
 <% if section.recorded_request? %>
 ```http
@@ -25,7 +25,7 @@
 
 <% end %>
 <% if section.parameters? %>
-### <span id="<%= section.header_ref %>-parameters">Parameters</span>
+### Parameters
 
 <% if section.custom_parameters_info %>
 <%= section.custom_parameters_info %>
@@ -42,7 +42,7 @@ All <%= resource %> **must** be sent in an array nested under a top level
 <% end %>
 
 <% if section.recorded_request? && section.request_json.present? %>
-### <span id="<%= section.header_ref %>-example">Example</span>
+### Example
 
 <% if section.example_explanation.present? %>
 <%= section.example_explanation %>
@@ -56,7 +56,7 @@ All <%= resource %> **must** be sent in an array nested under a top level
 <% end %>
 <% end %>
 <% if section.recorded_response? %>
-### <span id="<%= section.header_ref %>-response">Response</span>
+### Response
 
 ```http
 Status: <%= section.response_status %>
@@ -72,7 +72,7 @@ Status: <%= section.response_status %>
 ```
 <% end %>
 
-### <span id="<%= section.header_ref %>-curl-example">Curl Example</span>
+### Curl Example
 
 ```sh
 <%= RSpec::ApiDoc::StandardCurlExample.new(section).build %>


### PR DESCRIPTION
Now that we've switched to hosting our API docs with Docsify, we don't need the span tags to ensure that the section navigation works properly. They also appear in the search results on Docsify, which makes the search hard to read and a little unsightly.

Resolves #9 