### PR TITLE
Update the allowed ruby version range to allow for ruby v3

### DIFF
--- a/lib/rspec/api_doc/version.rb
+++ b/lib/rspec/api_doc/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module ApiDoc
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/rspec-api_doc.gemspec
+++ b/rspec-api_doc.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.5'
+  spec.required_ruby_version = '>= 2.5', '< 4'
 
   spec.add_runtime_dependency "rack-test", ">= 0.6.3"
   spec.add_runtime_dependency "rspec-core", "~> 3.2"


### PR DESCRIPTION
Previous requirement was twiddle-waka 2.5 (~>2.5) which excludes v3.

The other dependencies of this gem do not appear to have any requirements that would conflict with this version change, either.

redcarpet: https://github.com/vmg/redcarpet/blob/5f8ce6d3ab5f5dab77af0695cd162f851530d47a/redcarpet.gemspec does not declare a ruby version requirement.

github-markup: https://github.com/github/markup/blob/cb3554f06c9496ac8fabe5dd6bb5c9a9d512ac22/github-markup.gemspec also does not declare a ruby version requirement.

yard: https://github.com/lsegal/yard/blob/589f5254f9d9768922ae8bb9be798c6df3bbec8d/yard.gemspec also does not declare a ruby version requirement.

rubocop: https://github.com/rubocop/rubocop/blob/2e52af0e33cc6387f7c8495b52f66c8f2f46a804/rubocop.gemspec#L12 requires ruby >= 2.2.2

rspec-core (a runtime dependency): https://github.com/rspec/rspec-core/blob/c13d083a3298e4a3191552927c88b7df9cc05b22/rspec-core.gemspec#L26 requires ruby >= 1.8.7

rack-test (a runtime dependency): https://github.com/rack/rack-test/tree/acdbee66fc765f15c2d3a1a372c368fe8ee0a49c also does not declare a ruby version requirement.

To be fair, these are _all_ older versions of every gem, and should perhaps be updated to a somewhat newer version, but as it stands, the change in ruby version should not cause a conflict.