### PR TITLE
Adds specs, removes URI.escape (deprecated) and replaces with CGI.escape.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /.bundle/
 /.yardoc
 /.rspec-local

--- a/lib/rspec/api_doc/strings.rb
+++ b/lib/rspec/api_doc/strings.rb
@@ -1,12 +1,10 @@
-require 'uri'
-
 module RSpec
   module ApiDoc
     module Strings
     module_function
 
       def pretty_escape(text, sep = '-')
-        URI.escape(text.strip.gsub(/[[:space:]]+/, sep))
+        CGI.escape(text.strip.gsub(/[[:space:]]+/, sep))
       end
 
       # Source 'active_support/core_ext/string/inflections'
@@ -21,8 +19,7 @@ module RSpec
 
       # Source 'active_support/core_ext/string/strip'
       def strip_heredoc(text)
-        # TODO: REMOVE TRY!
-        indent = text.scan(/^[ \t]*(?=\S)/).min.try(:size) || 0
+        indent = text.scan(/^[ \t]*(?=\S)/).min&.size || 0
         text.gsub(/^[ \t]{#{indent}}/, '')
       end
 

--- a/lib/rspec/api_doc/version.rb
+++ b/lib/rspec/api_doc/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module ApiDoc
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end

--- a/spec/rspec/api_doc/strings_spec.rb
+++ b/spec/rspec/api_doc/strings_spec.rb
@@ -1,0 +1,67 @@
+require 'rspec/api_doc/strings'
+
+module RSpec
+  module ApiDoc
+    RSpec.describe Strings do
+      describe ".pretty_escape" do
+        let(:expected_string) { 'three-little-birds' }
+        it "removes leading and trailing whitespace and replaces spaces with hyphens" do
+          text = " three little birds "
+          expect(subject.pretty_escape(text)).to eq(expected_string)
+        end
+
+        it "accepts a custom separator as a second argument" do
+          text = ' three little birds '
+          sep = 'z'
+          expect(subject.pretty_escape(text, sep)).to eq(expected_string.gsub('-', sep))
+        end
+
+        it "replaces two spaces with a single hyphen" do
+          text = 'three  little  birds'
+          expect(subject.pretty_escape(text)).to eq(expected_string)
+        end
+      end
+
+      describe ".titleize" do
+        let(:expected_string) { 'Three Little Birds' }
+        it "capitalizes the first letter of each word" do
+          text = 'three little birds'
+          expect(subject.titleize(text)).to eq(expected_string)
+        end
+
+        it "does not capitalize the first letter of the word begins with a single quote" do
+          %w[' ’ `].each do |single_quote|
+            text = "#{single_quote}three little birds"
+            expect(subject.titleize(text)).to eq(expected_string.gsub('T', "#{single_quote}t"))
+          end
+        end
+      end
+
+      describe ".squish" do
+        let(:expected_string) { 'three little birds' }
+        it "compresses sequential spaces down to a single space" do
+          text = 'three      little    birds'
+          expect(subject.squish(text)).to eq(expected_string)
+        end
+      end
+
+      describe ".strip_heredoc" do
+        let(:expected_string) { 'three little birds' }
+        it "removes all tabs and spaces from the beginning of lines" do
+          text = "\t\t\t  three little birds"
+          expect(subject.strip_heredoc(text)).to eq(expected_string)
+        end
+      end
+
+      describe ".blank?" do
+        it "returns true if the text is nil" do
+          expect(subject.blank?(nil)).to be_truthy
+        end
+
+        it "returns true if the text contains only spaces" do
+          expect(subject.blank?('          ')).to be_truthy
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
`URI.escape` is deprecated.

https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI/Escape.html

> This method is obsolete and should not be used. Instead, use CGI.escape, [URI.encode_www_form](https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI.html#method-c-encode_www_form) or [URI.encode_www_form_component](https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI.html#method-c-encode_www_form_component) depending on your specific use case.

This applies the remediation. I also resolved a lingering TODO (removing `try`), and wrote model specs for the `Strings` module, which was lacking. 